### PR TITLE
Adding bindings for xterm addons

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,18 @@ extern "C" {
     pub fn write(this: &Terminal, data: &str);
 }
 
+// FitAddon bindings
+#[wasm_bindgen(module = "@xterm/addon-fit")]
+extern "C" {
+    #[derive(Clone)]
+    pub type FitAddon;
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> FitAddon;
+
+    #[wasm_bindgen(method)]
+    pub fn fit(this: &FitAddon);
+
+    #[wasm_bindgen(method)]
+    pub fn activate(this: &FitAddon, terminal: &Terminal);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,12 @@ extern "C" {
 
     #[wasm_bindgen(method)]
     pub fn write(this: &Terminal, data: &str);
+
+    #[wasm_bindgen(method)]
+    pub unsafe fn cols(this: &Terminal) -> u16;
+
+    #[wasm_bindgen(method)]
+    pub unsafe fn rows(this: &Terminal) -> u16;
 }
 
 // FitAddon bindings
@@ -27,7 +33,4 @@ extern "C" {
 
     #[wasm_bindgen(method)]
     pub fn fit(this: &FitAddon);
-
-    #[wasm_bindgen(method)]
-    pub fn activate(this: &FitAddon, terminal: &Terminal);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ extern "C" {
     pub fn write(this: &Terminal, data: &str);
 
     #[wasm_bindgen(method)]
-    pub unsafe fn cols(this: &Terminal) -> u16;
+    pub fn resize(this: &Terminal, columns: u16, rows: u16);
 
     #[wasm_bindgen(method)]
-    pub unsafe fn rows(this: &Terminal) -> u16;
+    pub fn loadAddon(this: &Terminal, addon: &FitAddon);
 }
 
 // FitAddon bindings


### PR DESCRIPTION
Extending with bindings for:
- @xterm/addon-fit: To fit terminal to its parent